### PR TITLE
modify getSigner in SessionWallet

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -88,7 +88,7 @@ class SessionWallet {
             return Promise.resolve(this.signTxn(txnGroup)).then((txns) => {
                 return txns.map((tx) => {
                     return tx.blob;
-                });
+                }).filter((_, index) => indexesToSign.includes(index));
             });
         };
     }

--- a/dist/wallets/walletconnect.js
+++ b/dist/wallets/walletconnect.js
@@ -98,7 +98,7 @@ class WC {
                     return { txn: encodedTxn, signers: [] };
                 return { txn: encodedTxn };
             });
-            const request = utils_1.formatJsonRpcRequest("algo_signTxn", [txnsToSign]);
+            const request = (0, utils_1.formatJsonRpcRequest)("algo_signTxn", [txnsToSign]);
             const result = yield this.connector.sendCustomRequest(request);
             return result.map((element, idx) => {
                 return element

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export class SessionWallet {
       return Promise.resolve(this.signTxn(txnGroup)).then((txns) => {
         return txns.map((tx) => {
           return tx.blob;
-        });
+        }).filter((_, index) => indexesToSign.includes(index));
       });
     };
   }


### PR DESCRIPTION
change `getSigner` to return a `TransactionSigner` which doesn't return transactions that weren't signed by it. according to the docstring:
```
/**
 * This type represents a function which can sign transactions from an atomic transaction group.
 * @param txnGroup - The atomic group containing transactions to be signed
 * @param indexesToSign - An array of indexes in the atomic transaction group that should be signed
 * @returns A promise which resolves an array of encoded signed transactions. The length of the
 *   array will be the same as the length of indexesToSign, and each index i in the array
 *   corresponds to the signed transaction from txnGroup[indexesToSign[i]]
 */
```
**...The length of the array will be the same as the length of indexesToSign, and each index i in the array corresponds to the signed transaction from txnGroup[indexesToSign[i]]**